### PR TITLE
Remove reference to obsolete runservo.sh script.

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ option to proceed opening the application.
                     <li>Download the .TAR.GZ file</li>
                     <li>Expand the file (`tar zxf servo-latest.tar.gz`)</li>
                     <li>`cd servo`</li>
-                    <li>Execute the `./runservo.sh` script to run Servo</li>
+                    <li>Execute `./servo` to run Servo</li>
                 </ul>
             <div align="center">
                 <a href="https://servo.org/"><img src="doge-tiny.png"


### PR DESCRIPTION
It no longer exists as of https://github.com/servo/servo/commit/01c7ac785b557304b1008799785f13a725a347ce.