### PR TITLE
Add a .travis.yml for Homu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+os: linux
+dist: trusty
+
+language: python
+python:
+  - "2.7"
+
+branches:
+  only:
+    - master
+
+# Install Java 8 as required by vnu.jar
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install openjdk-8-jre
+
+install:
+  - pip install -r dev-requirements.txt
+
+script:
+  - html5validator
+
+notifications:
+  webhooks: http://build.servo.org:54856/travis

--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ value for the integrity attribute on the HTML tag including that resource.
 
 You can check if this worked by trying to load the page in a browser and
 looking for console messages. (Note that Servo doesn't support this quite yet!)
+
+## Local testing
+
+We use the [W3C's HTML5 validator](https://github.com/validator/validator),
+via the
+[`html5validator` Python package](https://github.com/svenkreiss/html5validator)
+.
+
+To run this locally, run:
+```console
+$ virtualenv2 venv
+$ source venv/bin/activate
+(venv2) $ pip install -r dev-requirements.txt
+(venv2) $ html5validator
+```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+html5validator == 0.2.6

--- a/index.html
+++ b/index.html
@@ -1,58 +1,58 @@
 <!doctype html>
 <html>
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Servo Developer Preview Downloads</title>
-    <link rel='stylesheet' href='css/bootstrap.css'
+    <link rel="stylesheet" href="css/bootstrap.css"
           integrity="sha512-++bHK0UNrNHW3LVNLzgTm2G7uOH6Kd+Ved0sskOL0+TY7pr5AcWQgR19kdjAhyyiQRDjFwXubDGqTvjnS09HNA=="
           crossorigin="anonymous"/>
-    <link rel='stylesheet' href='css/style.css'
+    <link rel="stylesheet" href="css/style.css"
           integrity="sha512-FQmucuHzxei8VvCDQqa5fJIzNaRw/q1pC3UTgQ94WNNws9Tt0A0egUWHxX7K5QNRZJJS53L9tTrLz0fDEqFdjA=="
           crossorigin="anonymous"/>
 </head>
 
 <body>
-<div class='container'>
-    <div class='row'>
-        <div class='col-sm-offset-2 col-sm-8'>
-            <h1 id='page-title' class='page-header'> Servo Developer Preview Downloads</h1>
+<div class="container">
+    <div class="row">
+        <div class="col-sm-offset-2 col-sm-8">
+            <h1 id="page-title" class="page-header"> Servo Developer Preview Downloads</h1>
         </div>
-        <div class='col-sm-offset-2 col-sm-8'>
-            <h3 class='description'><a href="https://servo.org/"><b>Servo</b></a>
+        <div class="col-sm-offset-2 col-sm-8">
+            <h3 class="description"><a href="https://servo.org/"><b>Servo</b></a>
             is a modern, high-performance browser engine being developed for
             application and embedded use.
             </h3>
         </div>
     </div>
     <br>
-    <div class='row'>
-        <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
+    <div class="row">
+        <div class="col-sm-offset-2 col-sm-8 col-lg-4">
 
-            <p class='info'>These pre-built nightly snapshots allow developers
+            <p class="info">These pre-built nightly snapshots allow developers
             to try Servo and <a href="https://github.com/servo/servo/issues/new">report
             issues</a> without <a href="https://github.com/servo/servo/blob/master/docs/HACKING_QUICKSTART.md">
             building Servo locally</a>.
             </p>
 
-            <p class='info'><b>Please don’t log into your bank with Servo just
+            <p class="info"><b>Please don’t log into your bank with Servo just
 yet!</b> Now that we’ve released our first developer preview, we’ll be
 investing in formal security audits and improving our security practices using
 both existing libraries and Rust -- more information coming soon!
             </p>
         </div>
-        <div class='col-sm-8 col-lg-4 col-sm-push-2 col-lg-push-0'>
+        <div class="col-sm-8 col-lg-4 col-sm-push-2 col-lg-push-0">
 <!-- Coming soon!
-            <a class='btn btn-primary btn-large' role='button'
-               href='nightly/windows/'>Windows Builds</a>
+            <a class="btn btn-primary btn-large" role="button"
+               href="nightly/windows/">Windows Builds</a>
 -->
-            <a class='btn btn-primary btn-large' role='button'
-               href='nightly/mac/servo-latest.dmg'>Mac OS X Build</a><br>
-            <a class='btn btn-primary btn-large' role='button'
-               href='nightly/linux/servo-latest.tar.gz'>Linux Build (64-bit)</a><br>
+            <a class="btn btn-primary btn-large" role="button"
+               href="nightly/mac/servo-latest.dmg">Mac OS X Build</a><br>
+            <a class="btn btn-primary btn-large" role="button"
+               href="nightly/linux/servo-latest.tar.gz">Linux Build (64-bit)</a><br>
 <!-- Coming soon!
-            <a class='btn btn-primary btn-large' role='button'
-               href='nightly/android/'>Android Builds</a><br>
+            <a class="btn btn-primary btn-large" role="button"
+               href="nightly/android/">Android Builds</a><br>
 -->
             <br><p> Windows and Android builds are coming soon!</p>
             <br><p>See the <a
@@ -62,8 +62,8 @@ for progress updates.</p>
         </div>
     </div>
     <div class="row">
-        <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
-            <h2 class='header'>Mac OS X Instructions</h2>
+        <div class="col-sm-offset-2 col-sm-8 col-lg-4">
+            <h2 class="header">Mac OS X Instructions</h2>
                 <ul>
                     <li>Click the "Mac OS X Build" button above to download the latest build</li>
                     <li>Open the downloaded `servo-latest.dmg` file</li>
@@ -76,8 +76,8 @@ unidentified developer." If the popup lacks a "proceed anyway" option, close
 it then right click Servo.app and click "Open." This time the popup will have an
 option to proceed opening the application.
         </div>
-        <div class='col-sm-8 col-lg-4 col-sm-push-2 col-lg-push-0'>
-            <h2 class='header'>Linux Instructions</h2>
+        <div class="col-sm-8 col-lg-4 col-sm-push-2 col-lg-push-0">
+            <h2 class="header">Linux Instructions</h2>
                 <ul>
                     <li>Click the "Linux Build" button above</li>
                     <li>Download the .TAR.GZ file</li>
@@ -91,24 +91,24 @@ option to proceed opening the application.
             </div>
         </div>
     </div>
-    <div class='row'>
-        <div class='col-sm-offset-2 col-sm-8'>
+    <div class="row">
+        <div class="col-sm-offset-2 col-sm-8">
 
-            <footer class='text-center'>
-                <div class='col-md-3'>
+            <footer class="text-center">
+                <div class="col-md-3">
                     <a href="https://servo.org/">Servo Home Page</a>
                 </div>
-                <div class='col-md-3'>
+                <div class="col-md-3">
                     <a href="https://www.github.com/servo">Contribute</a>
                 </div>
-                <div class='col-md-3'>
-                    <a href='https://github.com/servo/servo/wiki/Roadmap'>Follow Servo's Roadmap</a>
+                <div class="col-md-3">
+                    <a href="https://github.com/servo/servo/wiki/Roadmap">Follow Servo's Roadmap</a>
                 </div>
-                <div class='col-md-3'>
+                <div class="col-md-3">
                     <a href="http://blog.servo.org/">Read the Servo blog</a>
                 </div>
-                <div class='col-md-3'>
-                    <p class='text-muted'>#servo on irc.mozilla.org</p>
+                <div class="col-md-3">
+                    <p class="text-muted">#servo on irc.mozilla.org</p>
                 </div>
             </footer>
         </div>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ option to proceed opening the application.
                     <li>`cd servo`</li>
                     <li>Execute the `./runservo.sh` script to run Servo</li>
                 </ul>
-            <div align="center">
+            <div style="text-align:center">
                 <a href="https://servo.org/"><img src="doge-tiny.png"
                 alt="Servo's Doge Logo"></a>
             </div>


### PR DESCRIPTION
Currently, we use the W3C's "Nu HTML Checker"
(https://github.com/validator/validator) via a Python package,
https://github.com/svenkreiss/html5validator,
although the actual checker is written in Java 8.