### PR TITLE
Change "Mac OS X" to "macOS"

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ both existing libraries and Rust -- more information coming soon!
                href='nightly/windows/'>Windows Builds</a>
 -->
             <a class='btn btn-primary btn-large' role='button'
-               href='nightly/mac/servo-latest.dmg'>Mac OS X Build</a><br>
+               href='nightly/mac/servo-latest.dmg'>macOS Build</a><br>
             <a class='btn btn-primary btn-large' role='button'
                href='nightly/linux/servo-latest.tar.gz'>Linux Build (64-bit)</a><br>
 <!-- Coming soon!
@@ -63,9 +63,9 @@ for progress updates.</p>
     </div>
     <div class="row">
         <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
-            <h2 class='header'>Mac OS X Instructions</h2>
+            <h2 class='header'>macOS Instructions</h2>
                 <ul>
-                    <li>Click the "Mac OS X Build" button above to download the latest build</li>
+                    <li>Click the "macOS Build" button above to download the latest build</li>
                     <li>Open the downloaded `servo-latest.dmg` file</li>
                     <li>Drag Servo.app to the Applications folder</li>
                     <li>Double-click on Servo.app to run Servo</li>


### PR DESCRIPTION
This looks like it was supposed to have been fixed in PR #4 but got overwritten.