### PR TITLE
Fix "macOS" capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ both existing libraries and Rust -- more information coming soon!
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/windows-msvc/servo-latest.msi">Windows Build</a>
             <a class="btn btn-primary btn-large" role="button"
-               href="nightly/mac/servo-latest.dmg">MacOS Build</a><br>
+               href="nightly/mac/servo-latest.dmg">macOS Build</a><br>
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/linux/servo-latest.tar.gz">Linux Build (64-bit)</a><br>
 <!-- Coming soon!
@@ -59,7 +59,7 @@ for progress updates.</p>
     </div>
     <div class="row">
         <div class="col-sm-offset-2 col-sm-8 col-lg-4">
-            <h2 class="header">MacOS Instructions</h2>
+            <h2 class="header">macOS Instructions</h2>
                 <ul>
                     <li>Click the "macOS Build" button above to download the latest build</li>
                     <li>Open the downloaded `servo-latest.dmg` file</li>


### PR DESCRIPTION
The capitalization of "macOS" was not consistent in fe8303f912b0961f9a7ed1ae4e74a4e8777aa0cc.