### PR TITLE
Clarify that the Windows build is 64-bit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,9 @@ both existing libraries and Rust -- more information coming soon!
         </div>
         <div class="col-sm-8 col-lg-4 col-sm-push-2 col-lg-push-0">
             <a class="btn btn-primary btn-large" role="button"
-               href="nightly/windows-msvc/servo-latest.msi">Windows Build Installer</a>
+               href="nightly/windows-msvc/servo-latest.msi">Windows Build Installer (64-bit)</a><br>
             <a class="btn btn-primary btn-large" role="button"
-               href="nightly/windows-msvc/servo-latest.zip">Windows Build ZIP</a><br>
+               href="nightly/windows-msvc/servo-latest.zip">Windows Build ZIP (64-bit)</a><br>
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/mac/servo-latest.dmg">macOS Build</a><br>
             <a class="btn btn-primary btn-large" role="button"


### PR DESCRIPTION
C'mon. If you are gonna say that Linux is 64-bit only, you should also say that Windows is 64-bit only. (macOS goes without saying, though).

32-bit Windows still exists, and I am using it at this moment. 

I don't want to have to download an installer only to see this:

![image](https://user-images.githubusercontent.com/6258309/32982694-98c0bbc0-cc56-11e7-9efc-e552404e60d2.png)

An alternative solution is to make 32-bit builds as well, but I am not in charge of that…