### PR TITLE
Fix doge logo url

### DIFF
--- a/zh-TW/index.html
+++ b/zh-TW/index.html
@@ -93,7 +93,7 @@
                 </ul>
                 <div style="text-align:center">
                     <a href="https://servo.org/">
-                        <img src="doge-tiny.png" alt="Servo's Doge Logo">
+                        <img src="/doge-tiny.png" alt="Servo's Doge Logo">
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Help to fix the `doge` logo url which should be start with slash.
r? @jdm or @shinglyu 

Thanks.