### PR TITLE
Link to HTTPS blog page and match capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ option to proceed opening the application.
                     <a href="https://github.com/servo/servo/wiki/Roadmap">Follow Servo's Roadmap</a>
                 </div>
                 <div class="col-md-3">
-                    <a href="http://blog.servo.org/">Read the Servo blog</a>
+                    <a href="https://blog.servo.org/">Read the Servo Blog</a>
                 </div>
                 <div class="col-md-3">
                     <p class="text-muted">#servo on irc.mozilla.org</p>


### PR DESCRIPTION
Link to the blog page with HTTPS and match the capitalization of the rest of the section.