### PR TITLE
Remove www from GitHub URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ option to proceed opening the application.
                     <a href="https://servo.org/">Servo Home Page</a>
                 </div>
                 <div class="col-md-3">
-                    <a href="https://www.github.com/servo">Contribute</a>
+                    <a href="https://github.com/servo">Contribute</a>
                 </div>
                 <div class="col-md-3">
                     <a href="https://github.com/servo/servo/wiki/Roadmap">Follow Servo's Roadmap</a>


### PR DESCRIPTION
Site doesn't use it. Link to the page directly instead.