### PR TITLE
Remove download button for Windows build zip

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,6 @@ both existing libraries and Rust -- more information coming soon!
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/windows-msvc/servo-latest.exe">Windows Build Installer (64-bit)</a>
             <a class="btn btn-primary btn-large" role="button"
-               href="nightly/windows-msvc/servo-latest.zip">Windows Build ZIP (64-bit)</a><br>
-            <a class="btn btn-primary btn-large" role="button"
                href="nightly/mac/servo-latest.dmg">macOS Build</a><br>
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/linux/servo-latest.tar.gz">Linux Build (64-bit)</a><br>


### PR DESCRIPTION
I'll remove the zip generation and upload steps from Servo's packaging command as well.