### PR TITLE
Remove unneeded webhook notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,3 @@ deploy:
   on:
     branch: master
   condition: $TRAVIS_PULL_REQUEST = "false"
-
-notifications:
-  webhooks: http://build.servo.org:54856/travis


### PR DESCRIPTION
https://github.com/servo/saltfs/pull/906#issuecomment-436313032

Please also edit the Website URL at the top of https://github.com/servo/download.servo.org to https.