### PR TITLE
Add link to self-contained ZIP.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@ both existing libraries and Rust -- more information coming soon!
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/windows-msvc/servo-latest.exe">Windows Build Installer (64-bit)</a><br>
             <a class="btn btn-primary btn-large" role="button"
+               href="nightly/windows-msvc/servo-latest.zip">Windows Build (64-bit)</a><br>
+            <a class="btn btn-primary btn-large" role="button"
                href="nightly/mac/servo-latest.dmg">macOS Build</a><br>
             <a class="btn btn-primary btn-large" role="button"
                href="nightly/linux/servo-latest.tar.gz">Linux Build (64-bit)</a><br>


### PR DESCRIPTION
The ZIP should now contain the full set of known dependencies, so it should be a supported way of using Servo nightlies.