### PR TITLE
Label macOS download as x64

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                    href="nightly/uwp/servo-latest.zip">UWP (arm64/x64)</a><br>
 
                 <a class="btn btn-primary btn-large" id="button-macos" role="button"
-                   href="nightly/mac/servo-latest.dmg">macOS</a><br>
+                   href="nightly/mac/servo-latest.dmg">macOS (x64)</a><br>
 
                 <a class="btn btn-primary btn-large" id="button-linux" role="button"
                    href="nightly/linux/servo-latest.tar.gz">Linux (x64)</a><br>


### PR DESCRIPTION
Now that there is an ARM version of macOS it might be worth clarifying the download as x64.